### PR TITLE
fix: set strategy.fail-fast to false

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -32,6 +32,7 @@ jobs:
     # if services is empty, the build job is skipped
     if: "join(fromJSON(needs.setup.outputs.tfmigrate_targets), '') != ''"
     strategy:
+      fail-fast: false
       matrix:
         target: ${{fromJSON(needs.setup.outputs.tfmigrate_targets)}}
     env:
@@ -66,6 +67,7 @@ jobs:
     # if services is empty, the build job is skipped
     if: "join(fromJSON(needs.setup.outputs.terraform_targets), '') != ''"
     strategy:
+      fail-fast: false
       matrix:
         target: ${{fromJSON(needs.setup.outputs.terraform_targets)}}
     env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,6 +30,7 @@ jobs:
     # if services is empty, the build job is skipped
     if: "join(fromJSON(needs.setup.outputs.tfmigrate_targets), '') != ''"
     strategy:
+      fail-fast: false
       matrix:
         target: ${{fromJSON(needs.setup.outputs.tfmigrate_targets)}}
     env:
@@ -68,6 +69,7 @@ jobs:
     # if services is empty, the build job is skipped
     if: "join(fromJSON(needs.setup.outputs.terraform_targets), '') != ''"
     strategy:
+      fail-fast: false
       matrix:
         target: ${{fromJSON(needs.setup.outputs.terraform_targets)}}
     env:


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast

> When jobs.<job_id>.strategy.fail-fast is set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true

Job shouldn't be canceled.