### PR TITLE
Remove unused id attributes in workflows

### DIFF
--- a/.github/workflows/scaffold-tfmigrate.yaml
+++ b/.github/workflows/scaffold-tfmigrate.yaml
@@ -32,7 +32,7 @@ jobs:
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: suzuki-shunsuke/tfaction/scaffold-tfmigrate@main
-        id: scaffold-working-dir
+        id: scaffold-tfmigrate
         with:
           github_app_token: ${{ steps.generate_token.outputs.token }}
           migration_name: ${{ github.event.inputs.migration_name }}

--- a/.github/workflows/scaffold-tfmigrate.yaml
+++ b/.github/workflows/scaffold-tfmigrate.yaml
@@ -32,7 +32,6 @@ jobs:
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: suzuki-shunsuke/tfaction/scaffold-tfmigrate@main
-        id: scaffold-tfmigrate
         with:
           github_app_token: ${{ steps.generate_token.outputs.token }}
           migration_name: ${{ github.event.inputs.migration_name }}

--- a/.github/workflows/scaffold-working-directory.yaml
+++ b/.github/workflows/scaffold-working-directory.yaml
@@ -23,7 +23,6 @@ jobs:
           aqua_version: v1.19.2
 
       - uses: suzuki-shunsuke/tfaction/scaffold-working-dir@v0.5.16
-        id: scaffold-working-dir
 
       - name: Generate token
         id: generate_token


### PR DESCRIPTION
This workflow is not for workdir but for tfmigrate, then it is better to name the `id` attribute properlly.