### PR TITLE
fix: update actionlint.yaml to add explicit permissions

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -9,8 +9,11 @@ on:
     - .github/**
     - aqua/actionlint.yaml
 jobs:
-  default:
+  actionlint:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
     steps:
     - uses: actions/checkout@v3
     - uses: aquaproj/aqua-installer@v1.2.0


### PR DESCRIPTION
- The workflow has been errored when a default permission of GitHub Token is `Read` and there is something to comment to PR.
- This PR fixes the example work flow same with https://github.com/suzuki-shunsuke/actionlint-workflow