### PR TITLE
chore: remove aqua-policy.yaml

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,7 +1,5 @@
 ---
 name: actionlint
-env:
-  AQUA_POLICY_CONFIG: ${{ github.workspace }}/aqua-policy.yaml
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -7,7 +7,6 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   TFACTION_IS_APPLY: 'true'
-  AQUA_POLICY_CONFIG: ${{ github.workspace }}/aqua-policy.yaml
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/conftest-verify.yaml
+++ b/.github/workflows/conftest-verify.yaml
@@ -7,8 +7,6 @@ on:
     - '**.rego'
     - .github/workflows/conftest-verify.yaml
     - aqua/conftest.yaml
-env:
-  AQUA_POLICY_CONFIG: ${{ github.workspace }}/aqua-policy.yaml
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/hide_comment.yaml
+++ b/.github/workflows/hide_comment.yaml
@@ -5,7 +5,6 @@ on:
     branches: [main]
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  AQUA_POLICY_CONFIG: ${{ github.workspace }}/aqua-policy.yaml
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/opa-fmt.yaml
+++ b/.github/workflows/opa-fmt.yaml
@@ -7,8 +7,6 @@ on:
     - '**.rego'
     - .github/workflows/opa-fmt.yaml
     - aqua/opa.yaml
-env:
-  AQUA_POLICY_CONFIG: ${{ github.workspace }}/aqua-policy.yaml
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-module.yaml
+++ b/.github/workflows/release-module.yaml
@@ -13,7 +13,6 @@ permissions:
   contents: write
 env:
   TFACTION_TARGET: ${{github.event.inputs.module_path}}
-  AQUA_POLICY_CONFIG: ${{ github.workspace }}/aqua-policy.yaml
 jobs:
   release-module:
     name: "release-module (${{github.event.inputs.module_path}})"

--- a/.github/workflows/scaffold-module.yaml
+++ b/.github/workflows/scaffold-module.yaml
@@ -9,8 +9,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-env:
-  AQUA_POLICY_CONFIG: ${{ github.workspace }}/aqua-policy.yaml
 jobs:
   scaffold:
     runs-on: ubuntu-latest

--- a/.github/workflows/scaffold-tfmigrate.yaml
+++ b/.github/workflows/scaffold-tfmigrate.yaml
@@ -12,7 +12,6 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   TFACTION_TARGET: ${{ github.event.inputs.target }}
-  AQUA_POLICY_CONFIG: ${{ github.workspace }}/aqua-policy.yaml
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/scaffold-working-directory.yaml
+++ b/.github/workflows/scaffold-working-directory.yaml
@@ -9,7 +9,6 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   TFACTION_TARGET: ${{github.event.inputs.target}}
-  AQUA_POLICY_CONFIG: ${{ github.workspace }}/aqua-policy.yaml
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,6 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   TFACTION_IS_APPLY: 'false'
-  AQUA_POLICY_CONFIG: ${{ github.workspace }}/aqua-policy.yaml
 
 permissions:
   id-token: write

--- a/aqua-policy.yaml
+++ b/aqua-policy.yaml
@@ -1,8 +1,0 @@
----
-# aqua Policy
-# https://aquaproj.github.io/docs/tutorial-extras/policy-as-code
-registries:
-- type: standard
-  ref: semver(">= 3.0.0")
-packages:
-- registry: standard


### PR DESCRIPTION
From aqua v2, only standard registry is allowed by default.