### PR TITLE
ci: add a missing permission required from v0.7

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -7,6 +7,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   TFACTION_IS_APPLY: 'true'
 permissions:
+  actions: read
   id-token: write
   contents: read
   issues: read # this is required to `gh pr list`'s `-l` option


### PR DESCRIPTION
According to https://github.com/suzuki-shunsuke/tfaction/releases/tag/v0.7.0, `actions: read` is necessary to download the plan file.