### PR TITLE
Fix the input for list-targets action

### DIFF
--- a/.github/workflows/wc-setup.yaml
+++ b/.github/workflows/wc-setup.yaml
@@ -56,5 +56,5 @@ jobs:
 
       - uses: suzuki-shunsuke/tfaction/list-targets@233b3eebee1c48f18dfc917ef6a5cbc92510fc28 # v1.0.1-1
         id: list-targets
-        env:
-          GITHUB_TOKEN: ${{steps.generate_token.outputs.token}}
+        with:
+          github_token: ${{steps.generate_token.outputs.token}}


### PR DESCRIPTION
Seeing `action.yaml` in `list-targets`, GitHub API token should be passed by `github_token` input:
https://github.com/suzuki-shunsuke/tfaction/blob/v1.0.3/list-targets/action.yaml

Without it, `default: ${{ github.token }}` is used and it lacks the required `pull_requests` permission.

```
time="2024-02-08T09:15:05Z" level=fatal msg="get a pull request: GET https://api.github.com/repos/***/***/pulls/***: 403 Resource not accessible by integration []"
```

I guess the error message from ci-info:
https://github.com/suzuki-shunsuke/ci-info/blob/36542e1d5bf513b49be0432eea435dffaa0d463d/pkg/controller/controller.go#L123