### PR TITLE
Always run status-check job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,9 +40,14 @@ jobs:
       - renovate-config-validator
       - test
       - update-aqua-checksums
-    if: failure()
+    if: always()
     steps:
       - run: exit 1
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}
 
   conftest-verify:
     uses: ./.github/workflows/wc-conftest-verify.yaml


### PR DESCRIPTION
The status-check job should not be skipped just because a job it needs is skipped. This way it always runs but fails if a job failes or is cancelled.

See https://github.com/orgs/community/discussions/26822