### PR TITLE
added hashicorp/terraform-config-inspect

### DIFF
--- a/aqua/imports/terraform-config-inspect.yaml
+++ b/aqua/imports/terraform-config-inspect.yaml
@@ -1,0 +1,3 @@
+packages:
+  - name: hashicorp/terraform-config-inspect
+    version: 5a6f8d18746d3c23cd25f7a6d48429545f20962f


### PR DESCRIPTION
Hi, @suzuki-shunsuke 
I added `hashicorp/terraform-config-inspect` to aqua.
Because an error occured when execute `suzuki-shunsuke/tfaction/list-tagets` in test step.

```console
/bin/sh: 1: terraform-config-inspect: not found
Error: Command failed: terraform-config-inspect --json fastly
/bin/sh: 1: terraform-config-inspect: not found
```